### PR TITLE
Update CI because of deprecation

### DIFF
--- a/.github/workflows/linting.yaml
+++ b/.github/workflows/linting.yaml
@@ -2,7 +2,10 @@
 name: Linting
 
 # yamllint disable-line rule:truthy
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
 
 jobs:
   precommit:
@@ -73,7 +76,7 @@ jobs:
       - name: 🏗 Get pip cache dir
         id: pip-cache
         run: |
-          echo "::set-output name=dir::$(pip cache dir)"
+          echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
       - name: ⤵️ Restore cached Python PIP packages
         uses: actions/cache@v3
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: 🏗 Get pip cache dir
         id: pip-cache
         run: |
-          echo "::set-output name=dir::$(pip cache dir)"
+          echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
       - name: ⤵️ Restore cached Python PIP packages
         uses: actions/cache@v3
         with:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -2,7 +2,10 @@
 name: Testing
 
 # yamllint disable-line rule:truthy
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
 
 jobs:
   pytest:
@@ -23,7 +26,7 @@ jobs:
       - name: 🏗 Get pip cache dir
         id: pip-cache
         run: |
-          echo "::set-output name=dir::$(pip cache dir)"
+          echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
       - name: ⤵️ Restore cached Python PIP packages
         uses: actions/cache@v3
         with:
@@ -70,7 +73,7 @@ jobs:
       - name: 🏗 Get pip cache dir
         id: pip-cache
         run: |
-          echo "::set-output name=dir::$(pip cache dir)"
+          echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
       - name: ⤵️ Restore cached Python PIP packages
         uses: actions/cache@v3
         with:

--- a/.github/workflows/typing.yaml
+++ b/.github/workflows/typing.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: 🏗 Get pip cache dir
         id: pip-cache
         run: |
-          echo "::set-output name=dir::$(pip cache dir)"
+          echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
       - name: ⤵️ Restore cached Python PIP packages
         uses: actions/cache@v3
         with:


### PR DESCRIPTION
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/